### PR TITLE
1. Add support for compiling in esp idf and added esp32 assembly optimizations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,23 +1,36 @@
 cmake_minimum_required(VERSION 3.16)
 
-# set the project name
-project(fdk_aac)
+if (DEFINED ESP_PLATFORM)
+  # idf component
+  idf_component_register(
+    SRC_DIRS src src/libAACdec src/libFDK src/libSYS src/libArithCoding src/libMpegTPDec src/libSACdec src/libDRCdec src/libSBRdec src/libPCMutils
+    INCLUDE_DIRS src src/libAACdec src/libFDK src/libSYS src/libArithCoding src/libMpegTPDec src/libSACdec src/libDRCdec src/libSBRdec src/libPCMutils
+    REQUIRES arduino-esp32
+  )
 
-# lots of warnings and all warnings as errors
-## add_compile_options(-Wall -Wextra )
-set(CMAKE_CXX_STANDARD 17)
+  target_compile_options(${COMPONENT_LIB} INTERFACE -Wno-error -Wno-format -Wno-format-security -Wformat=0)
+  target_compile_options(${COMPONENT_LIB} PRIVATE -DUSE_DEFAULT_STDLIB)
+  add_compile_definitions(ESP32)
+else()
+    # set the project name
+    project(fdk_aac)
 
-file(GLOB_RECURSE SRC_LIST_CPP CONFIGURE_DEPENDS  "${PROJECT_SOURCE_DIR}/src/*.cpp" )
+    # lots of warnings and all warnings as errors
+    ## add_compile_options(-Wall -Wextra )
+    set(CMAKE_CXX_STANDARD 17)
 
-# define libraries
-add_library (fdk_aac ${SRC_LIST_CPP})
+    file(GLOB_RECURSE SRC_LIST_CPP CONFIGURE_DEPENDS  "${PROJECT_SOURCE_DIR}/src/*.cpp" )
 
-# prevent compile errors
-#target_compile_options(fdk_aac PRIVATE -DUSE_DEFAULT_STDLIB)
+    # define libraries
+    add_library (fdk_aac ${SRC_LIST_CPP})
 
-# define location for header files
-target_include_directories(fdk_aac PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src )
+    # prevent compile errors
+    #target_compile_options(fdk_aac PRIVATE -DUSE_DEFAULT_STDLIB)
 
-# build examples
-add_subdirectory( "${CMAKE_CURRENT_SOURCE_DIR}/examples/decode")
-add_subdirectory( "${CMAKE_CURRENT_SOURCE_DIR}/examples/encode")
+    # define location for header files
+    target_include_directories(fdk_aac PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/src )
+
+    # build examples
+    add_subdirectory( "${CMAKE_CURRENT_SOURCE_DIR}/examples/decode")
+    add_subdirectory( "${CMAKE_CURRENT_SOURCE_DIR}/examples/encode")
+endif()

--- a/src/libAACdec/conceal.cpp
+++ b/src/libAACdec/conceal.cpp
@@ -1931,6 +1931,9 @@ INT CConcealment_TDFading(
       }
       CConcealment_TDFading_doLinearFadingSteps(&fadingSteps[0]);
       break;
+    default:
+      fadeStop = (FIXP_DBL)MAXVAL_DBL;
+      break;
   }
 
   /*

--- a/src/libFDK/esp32/fixmul_esp32.h
+++ b/src/libFDK/esp32/fixmul_esp32.h
@@ -7,8 +7,12 @@
 #define FUNCTION_fixmul_DD
 #define FUNCTION_fixmuldiv2BitExact_DD
 #define FUNCTION_fixmulBitExact_DD
+#define FUNCTION_fixpow2div2_D
+#define FUNCTION_fixpow2_D
 #define fixmuldiv2BitExact_DD(a, b) fixmuldiv2_DD(a, b)
 #define fixmulBitExact_DD(a, b) fixmul_DD(a, b)
+#define fixpow2div2_D(a) fixmuldiv2_DD(a, a)
+#define fixpow2_D(a) fixmul_DD(a, a)
 
 inline LONG fixmuldiv2_DD(const LONG a, const LONG b) {
   LONG result1 = 0;

--- a/src/libFDK/esp32/fixmul_esp32.h
+++ b/src/libFDK/esp32/fixmul_esp32.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "libFDK/FDK_archdef.h"
+#include "libSYS/machine_type.h"
+
+#define FUNCTION_fixmuldiv2_DD
+#define FUNCTION_fixmul_DD
+#define FUNCTION_fixmuldiv2BitExact_DD
+#define FUNCTION_fixmulBitExact_DD
+#define fixmuldiv2BitExact_DD(a, b) fixmuldiv2_DD(a, b)
+#define fixmulBitExact_DD(a, b) fixmul_DD(a, b)
+
+inline LONG fixmuldiv2_DD(const LONG a, const LONG b) {
+  LONG result1 = 0;
+  asm("MULSH %0, %1, %2;" : "=a"(result1) : "a"(a), "a"(b));
+  return result1;
+}
+
+inline LONG fixmul_DD(const LONG a, const LONG b) {
+  LONG result1 = 0;
+  asm("MULSH %[res], %[val1], %[val2]; \
+       SLLI %[res], %[res], 1;"
+        : [res] "=a"(result1) 
+        : [val1] "a" (a), [val2] "a" (b));
+  return result1;
+}

--- a/src/libFDK/fixmul.h
+++ b/src/libFDK/fixmul.h
@@ -106,6 +106,11 @@ amm-info@iis.fraunhofer.de
 #include "libFDK/FDK_archdef.h"
 #include "libSYS/machine_type.h"
 
+
+#if defined(ESP32)
+#include "libFDK/esp32/fixmul_esp32.h"
+#endif
+
 // #if defined(__arm__)
 // #include "arm/fixmul_arm.h"
 

--- a/src/libMpegTPDec/tpdec_adts.cpp
+++ b/src/libMpegTPDec/tpdec_adts.cpp
@@ -167,7 +167,7 @@ TRANSPORTDEC_ERROR adtsRead_DecodeHeader(HANDLE_ADTS pAdts,
                                          CSAudioSpecificConfig *pAsc,
                                          HANDLE_FDK_BITSTREAM hBs,
                                          const INT ignoreBufferFullness) {
-  INT crcReg;
+  INT crcReg = 0;
 
   INT valBits;
   INT cmp_buffer_fullness;

--- a/src/libSYS/genericStds.cpp
+++ b/src/libSYS/genericStds.cpp
@@ -206,9 +206,9 @@ char *FDKstrncpy(char *dest, const char *src, UINT n) {
       } else {
         ptr = heap_caps_calloc(n, size, MALLOC_CAP_8BIT);
       }
-      LOG_FDK(FDKInfo, "==> calloc_align_%d(%d,%d) -> 0x%x [available MEMORY 8BIT : %d ; 32BIT : %d]", alignment_effective, n, size, (uint32_t)ptr, heap_caps_get_free_size(MALLOC_CAP_8BIT), heap_caps_get_free_size(MALLOC_CAP_32BIT));
+      LOG_FDK(FDKInfo, "==> calloc_align_%d(%d,%d) -> 0x%lu [available MEMORY 8BIT : %d ; 32BIT : %d]", alignment_effective, n, size, (uint32_t)ptr, heap_caps_get_free_size(MALLOC_CAP_8BIT), heap_caps_get_free_size(MALLOC_CAP_32BIT));
     } else {
-      LOG_FDK(FDKInfo, "==> ps_calloc(%d, %d) -> 0x%x", n, size, ptr);
+      LOG_FDK(FDKInfo, "==> ps_calloc(%d, %d) -> 0x%p", n, size, ptr);
     }
     if (ptr==nullptr) {
       LOG_FDK(FDKError, "Memory allocations error!!! -> largest free block [8BIT MEMORY: %d | 32BIT MEMORY: %d]", heap_caps_get_largest_free_block(MALLOC_CAP_8BIT), heap_caps_get_largest_free_block(MALLOC_CAP_32BIT));


### PR DESCRIPTION
I noticed in the README.md, you had stated that you had intentionally "removed all optimized processor specific code (e.g. for ARM, 386 and mips), so that it will compile with the same code on all environements."

I'm hoping you mean you removed them because they weren't useful to the arduino port?

I have created the optimized processor specific code for the esp32 as it was unable to decode HE-AACv2 (Aka AAC with SBR & PS) fast enough to output to my i2s source (Note: I also had to increase the i2s_chan_config_t.dma_frame_num = 4096 for it to play smoothly. I will create another PR for this shortly)

Let me know if you need anything more or think I've done anything wrong.